### PR TITLE
[DEV] Domain layer 구현

### DIFF
--- a/src/main/java/com/example/issuetracker_server/IssueTrackerServerApplication.java
+++ b/src/main/java/com/example/issuetracker_server/IssueTrackerServerApplication.java
@@ -28,20 +28,28 @@ src
                     │   ├── member
                     │   │   ├── Member.java
                     │   │   └── MemberRepository.java
-                    │   └── project
-                    │       ├── Project.java
-                    │       └── ProjectRepository.java
+                    │   ├── project
+                    │   │   ├── Project.java
+                    │   │   └── ProjectRepository.java
+                    │   └── ...
+                    │
                     ├── service
                     │   ├── MemberService.java
-                    │   └── ProjectService.java
+                    │   ├── ProjectService.java
+                    │   └── ...
+                    │
                     ├── controller
                     │   ├── MemberController.java
-                    │   └── ProjectController.java
+                    │   ├── ProjectController.java
+                    │   └── ...
+                    │
                     └── dto
                         ├── member
                         │   ├── MemberRequestDto.java
                         │   └── MemberResponseDto.java
-                        └── project
-                            ├── ProjectRequestDto.java
-                            └── ProjectResponseDto.java
+                        ├── project
+                        │   ├── ProjectRequestDto.java
+                        │   └── ProjectResponseDto.java
+                        │
+                        └── ...
  */

--- a/src/main/java/com/example/issuetracker_server/IssueTrackerServerApplication.java
+++ b/src/main/java/com/example/issuetracker_server/IssueTrackerServerApplication.java
@@ -14,3 +14,34 @@ public class IssueTrackerServerApplication {
     }
 
 }
+
+/*
+target
+src
+└── main
+    └── java
+        └── com
+            └── example
+                └── com.example.issuetracker_server
+                    ├── IssueTrackerServerApplication.java
+                    ├── domain
+                    │   ├── member
+                    │   │   ├── Member.java
+                    │   │   └── MemberRepository.java
+                    │   └── project
+                    │       ├── Project.java
+                    │       └── ProjectRepository.java
+                    ├── service
+                    │   ├── MemberService.java
+                    │   └── ProjectService.java
+                    ├── controller
+                    │   ├── MemberController.java
+                    │   └── ProjectController.java
+                    └── dto
+                        ├── member
+                        │   ├── MemberRequestDto.java
+                        │   └── MemberResponseDto.java
+                        └── project
+                            ├── ProjectRequestDto.java
+                            └── ProjectResponseDto.java
+ */

--- a/src/main/java/com/example/issuetracker_server/domain/comment/Comment.java
+++ b/src/main/java/com/example/issuetracker_server/domain/comment/Comment.java
@@ -1,0 +1,33 @@
+package com.example.issuetracker_server.domain.comment;
+
+import com.example.issuetracker_server.domain.BaseTimeEntity;
+import com.example.issuetracker_server.domain.issue.Issue;
+import com.example.issuetracker_server.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private Member author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id", nullable = false)
+    private Issue issue;
+
+    @Column(length = 1000, nullable = false)
+    private String content;
+}

--- a/src/main/java/com/example/issuetracker_server/domain/issue/Issue.java
+++ b/src/main/java/com/example/issuetracker_server/domain/issue/Issue.java
@@ -1,0 +1,51 @@
+package com.example.issuetracker_server.domain.issue;
+
+import com.example.issuetracker_server.domain.BaseTimeEntity;
+import com.example.issuetracker_server.domain.member.Member;
+import com.example.issuetracker_server.domain.project.Project;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Issue extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(length = 5000, nullable = false)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private Member reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assignee_id")
+    private Member assignee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fixer_id")
+    private Member fixer;
+
+    @Enumerated(EnumType.STRING)
+    private Priority priority;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private State state;
+}

--- a/src/main/java/com/example/issuetracker_server/domain/issue/Priority.java
+++ b/src/main/java/com/example/issuetracker_server/domain/issue/Priority.java
@@ -1,0 +1,8 @@
+package com.example.issuetracker_server.domain.issue;
+
+public enum Priority {
+    CRITICAL,  // 매우 긴급한 우선순위
+    HIGH,      // 높은 우선순위
+    MEDIUM,    // 중간 우선순위
+    LOW        // 낮은 우선순위
+}

--- a/src/main/java/com/example/issuetracker_server/domain/issue/State.java
+++ b/src/main/java/com/example/issuetracker_server/domain/issue/State.java
@@ -1,0 +1,9 @@
+package com.example.issuetracker_server.domain.issue;
+
+public enum State {
+    NEW,
+    ASSIGNED,
+    FIXED,
+    RESOLVED,
+    CLOSED
+}

--- a/src/main/java/com/example/issuetracker_server/domain/member/Member.java
+++ b/src/main/java/com/example/issuetracker_server/domain/member/Member.java
@@ -1,0 +1,31 @@
+package com.example.issuetracker_server.domain.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Member {
+
+    @Id
+    private String id;
+
+    @Column(length = 50, nullable = false)
+    private String password;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+
+    @Column(length = 50, nullable = false)
+    private String mail;
+
+
+}

--- a/src/main/java/com/example/issuetracker_server/domain/memberproject/MemberProject.java
+++ b/src/main/java/com/example/issuetracker_server/domain/memberproject/MemberProject.java
@@ -1,0 +1,34 @@
+package com.example.issuetracker_server.domain.memberproject;
+
+import com.example.issuetracker_server.domain.member.Member;
+import com.example.issuetracker_server.domain.project.Project;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberProject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10, nullable = false)
+    private Role role;
+
+}

--- a/src/main/java/com/example/issuetracker_server/domain/memberproject/Role.java
+++ b/src/main/java/com/example/issuetracker_server/domain/memberproject/Role.java
@@ -1,0 +1,8 @@
+package com.example.issuetracker_server.domain.memberproject;
+
+public enum Role {
+    ADMIN,
+    TESTER,
+    PL,
+    DEV
+}

--- a/src/main/java/com/example/issuetracker_server/domain/project/Project.java
+++ b/src/main/java/com/example/issuetracker_server/domain/project/Project.java
@@ -9,13 +9,13 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Project extends BaseTimeEntity{
+public class Project extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 500, nullable=false)
+    @Column(length = 500, nullable = false)
     private String title;
 
     @Builder

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,16 @@
 spring.application.name=IssueTracker_Server
-
+#setting h2
 spring.h2.console.enabled=true
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.h2.console.path=/h2-console
+#setting h2 db
+spring.datasource.url=jdbc:h2:file:~/test
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+#show sql
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+#ddl auto
+spring.jpa.hibernate.ddl-auto=create


### PR DESCRIPTION
### 요약
- DB table을 참고하여 Domain layer를 설계했습니다.
- 구현 중 필요한 경우 기존의 DB 설계를 약간 수정하였습니다.

### 설명
- 각 도메인 클래스를 적절한 위치에 생성하였습니다.
- 필요한 경우 enum class를 정의하여, 도메인 클래스의 컬럼으로 추가하였습니다.
  - Enum: `State`, `Priority`, `Role`
- 현재까지 구현된 파일은 다음과 같습니다.
> <img width="361" alt="image" src="https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/27052038/9a4319cd-e650-4d4c-a10f-a5aa4fefa430">

- 수정된 최종 DB diagram은 다음과 같습니다.
> ![SWE JAP DB](https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/27052038/d2820000-ca99-49a9-8438-56e077cbd867)