### PR TITLE
[DEV] MemberProjectService.getRole(...) 구현

### DIFF
--- a/src/main/java/com/example/issuetracker_server/domain/memberproject/MemberProjectRepository.java
+++ b/src/main/java/com/example/issuetracker_server/domain/memberproject/MemberProjectRepository.java
@@ -2,5 +2,8 @@ package com.example.issuetracker_server.domain.memberproject;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberProjectRepository extends JpaRepository<MemberProject, Long> {
+    Optional<MemberProject> findByMemberIdAndProjectId(String memberId, Long projectId);
 }

--- a/src/main/java/com/example/issuetracker_server/service/memberproject/MemberProjectService.java
+++ b/src/main/java/com/example/issuetracker_server/service/memberproject/MemberProjectService.java
@@ -1,8 +1,13 @@
 package com.example.issuetracker_server.service.memberproject;
 
+import com.example.issuetracker_server.domain.memberproject.Role;
 import com.example.issuetracker_server.dto.project.ProjectsSaveRequestDto;
+
+import java.util.Optional;
 
 public interface MemberProjectService {
 
     Long save(Long projectId, ProjectsSaveRequestDto.Member member);
+
+    Optional<Role> getRole(String uId, Long pId);
 }

--- a/src/main/java/com/example/issuetracker_server/service/memberproject/MemberProjectServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/memberproject/MemberProjectServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.issuetracker_server.domain.member.Member;
 import com.example.issuetracker_server.domain.member.MemberRepository;
 import com.example.issuetracker_server.domain.memberproject.MemberProject;
 import com.example.issuetracker_server.domain.memberproject.MemberProjectRepository;
+import com.example.issuetracker_server.domain.memberproject.Role;
 import com.example.issuetracker_server.domain.project.Project;
 import com.example.issuetracker_server.domain.project.ProjectRepository;
 import com.example.issuetracker_server.dto.project.ProjectsSaveRequestDto;
@@ -12,6 +13,8 @@ import com.example.issuetracker_server.exception.ProjectNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -41,4 +44,10 @@ public class MemberProjectServiceImpl implements MemberProjectService {
         return memberProjectRepository.save(toEntity(projectId, member)).getId();
     }
 
+    @Override
+    @Transactional
+    public Optional<Role> getRole(String memberId, Long projectId) {
+        return memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+                .map(MemberProject::getRole);
+    }
 }


### PR DESCRIPTION
### 설명
- 유저가 해당 프로젝트에서 어떤 역할을 맡고 있는지 찾을 수 있는 service 함수를 구현했습니다.
- MemberProjectService.getRole(String memberId, Long projectId)로 2개의 파라미터를 사용합니다.
- 특정 역할이 할 수 있는 일에 대한 controller를 구현할 경우 다음과 같이 활용할 수 있습니다!

> ```java
>         Optional<Role> role = memberProjectService.getRole(id, projectId);
>         if (role.isEmpty() || role.get() != Role.TESTER) {
>             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
>         }
> ```