### PR TITLE
[DEV] CommentController API 구현

### DIFF
--- a/src/main/java/com/example/issuetracker_server/controller/CommentController.java
+++ b/src/main/java/com/example/issuetracker_server/controller/CommentController.java
@@ -1,0 +1,133 @@
+package com.example.issuetracker_server.controller;
+
+import com.example.issuetracker_server.domain.comment.Comment;
+import com.example.issuetracker_server.domain.issue.Issue;
+import com.example.issuetracker_server.domain.member.Member;
+import com.example.issuetracker_server.dto.comment.CommentRequestDto;
+import com.example.issuetracker_server.dto.member.MemberInfoDto;
+import com.example.issuetracker_server.service.comment.CommentService;
+import com.example.issuetracker_server.service.comment.CommentServiceImpl;
+import com.example.issuetracker_server.service.issue.IssueServiceImpl;
+import com.example.issuetracker_server.service.member.MemberService;
+import com.example.issuetracker_server.service.member.MemberServiceImpl;
+import com.example.issuetracker_server.service.project.ProjectService;
+import com.example.issuetracker_server.service.project.ProjectServiceImpl;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/project/{projectId}/issue/{issueId}/comment")
+public class CommentController {
+
+    @Autowired
+    private CommentServiceImpl commentService;
+
+    @Autowired
+    private MemberServiceImpl memberService;
+
+    @Autowired
+    private ProjectServiceImpl projectService;
+
+    @Autowired
+    private IssueServiceImpl issueService;
+
+    @PostMapping("/")
+    public ResponseEntity<?> createComment(@PathVariable Long projectId, @PathVariable Long issueId, @RequestParam String id, @RequestParam String pw, @RequestBody CommentRequestDto requestDto) {
+        if(!memberService.login(id, pw)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if(!memberService.isMemberOfProject(projectId, id)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        Optional<Member> member = memberService.getMember(id);
+        Optional<Issue> issue = issueService.getIssue(issueId);
+
+        if(member.isPresent() && issue.isPresent())
+        {
+            Comment comment = new Comment();
+            comment.setContent(requestDto.getContent());
+            comment.setAuthor(member.get());
+            comment.setIssue(issue.get());
+            comment.setCreatedDate(LocalDateTime.now());
+            commentService.save(comment);
+
+            return ResponseEntity.status(HttpStatus.OK).build();
+        }
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<?> getComments(@PathVariable Long projectId, @PathVariable Long issueId, @RequestParam String id, @RequestParam String pw)
+    {
+        if(!memberService.login(id, pw)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if(!memberService.isMemberOfProject(projectId, id)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        List<Comment> comments = commentService.findByIssueId(issueId);
+        return ResponseEntity.ok(comments);
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<?> updateComment(@PathVariable Long projectId, @PathVariable Long issueId, @PathVariable Long commentId, @RequestParam String id, @RequestParam String pw, @RequestBody CommentRequestDto requestDto)
+    {
+        if(!memberService.login(id, pw)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if(!memberService.isMemberOfProject(projectId, id)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        Optional<Comment> optionalComment = commentService.findById(commentId);
+        if(optionalComment.isPresent()) {
+            Comment comment = optionalComment.get();
+            if(!comment.getAuthor().getId().equals(id)) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+            comment.setContent(requestDto.getContent());
+            commentService.save(comment);
+            return ResponseEntity.status(HttpStatus.OK).build();
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable Long projectId, @PathVariable Long issueId, @PathVariable Long commentId, @RequestParam String id, @RequestParam String pw) {
+        if(!memberService.login(id, pw)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        if(!memberService.isMemberOfProject(projectId, id)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        Optional<Comment> optionalComment = commentService.findById(commentId);
+        if(optionalComment.isPresent()) {
+            Comment comment = optionalComment.get();
+            if(!comment.getAuthor().getId().equals(id)) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
+            commentService.delete(commentId);
+            return ResponseEntity.status(HttpStatus.OK).build();
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+
+    }
+
+
+
+}

--- a/src/main/java/com/example/issuetracker_server/controller/CommentController.java
+++ b/src/main/java/com/example/issuetracker_server/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.example.issuetracker_server.domain.comment.Comment;
 import com.example.issuetracker_server.domain.issue.Issue;
 import com.example.issuetracker_server.domain.member.Member;
 import com.example.issuetracker_server.dto.comment.CommentRequestDto;
+import com.example.issuetracker_server.dto.comment.CommentResponseDto;
 import com.example.issuetracker_server.dto.member.MemberInfoDto;
 import com.example.issuetracker_server.service.comment.CommentService;
 import com.example.issuetracker_server.service.comment.CommentServiceImpl;
@@ -78,7 +79,7 @@ public class CommentController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        List<Comment> comments = commentService.findByIssueId(issueId);
+        List<CommentResponseDto> comments = commentService.findByIssueId(issueId);
         return ResponseEntity.ok(comments);
     }
 

--- a/src/main/java/com/example/issuetracker_server/domain/comment/CommentRepository.java
+++ b/src/main/java/com/example/issuetracker_server/domain/comment/CommentRepository.java
@@ -2,5 +2,8 @@ package com.example.issuetracker_server.domain.comment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByIssueId(Long issueId);
 }

--- a/src/main/java/com/example/issuetracker_server/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/issuetracker_server/domain/member/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.example.issuetracker_server.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 }

--- a/src/main/java/com/example/issuetracker_server/domain/project/ProjectRepository.java
+++ b/src/main/java/com/example/issuetracker_server/domain/project/ProjectRepository.java
@@ -1,9 +1,11 @@
 package com.example.issuetracker_server.domain.project;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
-    List<Project> findByUserId(List<Long> ids);
+    @Query("SELECT p FROM Project p WHERE p.id IN :ids")
+    List<Project> findByIds(List<Long> ids);
 }

--- a/src/main/java/com/example/issuetracker_server/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/example/issuetracker_server/dto/comment/CommentRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.issuetracker_server.dto.comment;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentRequestDto {
+    private String content;
+
+}

--- a/src/main/java/com/example/issuetracker_server/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/example/issuetracker_server/dto/comment/CommentResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.issuetracker_server.dto.comment;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentResponseDto {
+
+    public Long comment_id;
+    public String author_id;
+    public String author_name;
+    public String content;
+    public String created_date;
+}

--- a/src/main/java/com/example/issuetracker_server/service/comment/CommentService.java
+++ b/src/main/java/com/example/issuetracker_server/service/comment/CommentService.java
@@ -1,0 +1,19 @@
+package com.example.issuetracker_server.service.comment;
+
+import com.example.issuetracker_server.domain.comment.Comment;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentService {
+
+    void save(Comment comment);
+
+    List<Comment> findByIssueId(Long issueId);
+
+    Optional<Comment> findById(Long commentId);
+
+    void delete(Long commentId);
+
+
+}

--- a/src/main/java/com/example/issuetracker_server/service/comment/CommentService.java
+++ b/src/main/java/com/example/issuetracker_server/service/comment/CommentService.java
@@ -1,6 +1,7 @@
 package com.example.issuetracker_server.service.comment;
 
 import com.example.issuetracker_server.domain.comment.Comment;
+import com.example.issuetracker_server.dto.comment.CommentResponseDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,7 +10,7 @@ public interface CommentService {
 
     void save(Comment comment);
 
-    List<Comment> findByIssueId(Long issueId);
+    List<CommentResponseDto> findByIssueId(Long issueId);
 
     Optional<Comment> findById(Long commentId);
 

--- a/src/main/java/com/example/issuetracker_server/service/comment/CommentServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/comment/CommentServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.issuetracker_server.service.comment;
 
 import com.example.issuetracker_server.domain.comment.Comment;
 import com.example.issuetracker_server.domain.comment.CommentRepository;
+import com.example.issuetracker_server.dto.comment.CommentResponseDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,8 +26,20 @@ public class CommentServiceImpl implements CommentService{
     }
 
     @Override
-    public List<Comment> findByIssueId(Long issueId) {
-        return commentRepository.findByIssueId(issueId);
+    public List<CommentResponseDto> findByIssueId(Long issueId) {
+        List<CommentResponseDto> commentDtos = null;
+        List<Comment> comments = commentRepository.findByIssueId(issueId);
+        for(Comment comment : comments) {
+            CommentResponseDto commentResponseDto = new CommentResponseDto();
+            commentResponseDto.setComment_id(comment.getId());
+            commentResponseDto.setContent(comment.getContent());
+            commentResponseDto.setCreated_date(comment.getCreatedDate().toString());
+            commentResponseDto.setAuthor_name(comment.getAuthor().getName());
+            commentResponseDto.setAuthor_id(comment.getAuthor().getId());
+            commentDtos.add(commentResponseDto);
+        }
+
+        return commentDtos;
     }
 
     @Override

--- a/src/main/java/com/example/issuetracker_server/service/comment/CommentServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/comment/CommentServiceImpl.java
@@ -1,0 +1,44 @@
+package com.example.issuetracker_server.service.comment;
+
+import com.example.issuetracker_server.domain.comment.Comment;
+import com.example.issuetracker_server.domain.comment.CommentRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService{
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Override
+    @Transactional
+    public void save(Comment comment)
+    {
+        commentRepository.save(comment);
+    }
+
+    @Override
+    public List<Comment> findByIssueId(Long issueId) {
+        return commentRepository.findByIssueId(issueId);
+    }
+
+    @Override
+    public Optional<Comment> findById(Long commentId) {
+        return commentRepository.findById(commentId);
+    }
+
+    @Override
+    public void delete(Long commentId) {
+        commentRepository.deleteById(commentId);
+
+    }
+
+
+}

--- a/src/main/java/com/example/issuetracker_server/service/issue/IssueService.java
+++ b/src/main/java/com/example/issuetracker_server/service/issue/IssueService.java
@@ -1,0 +1,11 @@
+package com.example.issuetracker_server.service.issue;
+
+import com.example.issuetracker_server.domain.issue.Issue;
+import com.example.issuetracker_server.domain.member.Member;
+
+import java.util.Optional;
+
+public interface IssueService {
+
+    Optional<Issue> getIssue(Long id);
+}

--- a/src/main/java/com/example/issuetracker_server/service/issue/IssueServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/issue/IssueServiceImpl.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class IssueServiceImpl {
+public class IssueServiceImpl implements IssueService{
 
     private final IssueRepository issueRepository;
     public Optional<Issue> getIssue(Long issueId) {

--- a/src/main/java/com/example/issuetracker_server/service/issue/IssueServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/issue/IssueServiceImpl.java
@@ -1,0 +1,18 @@
+package com.example.issuetracker_server.service.issue;
+
+import com.example.issuetracker_server.domain.issue.Issue;
+import com.example.issuetracker_server.domain.issue.IssueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class IssueServiceImpl {
+
+    private final IssueRepository issueRepository;
+    public Optional<Issue> getIssue(Long issueId) {
+        return issueRepository.findById(issueId);
+    }
+}

--- a/src/main/java/com/example/issuetracker_server/service/member/MemberService.java
+++ b/src/main/java/com/example/issuetracker_server/service/member/MemberService.java
@@ -1,5 +1,6 @@
 package com.example.issuetracker_server.service.member;
 
+import com.example.issuetracker_server.domain.member.Member;
 import com.example.issuetracker_server.dto.member.MemberInfoDto;
 import com.example.issuetracker_server.dto.member.MemberSignUpRequestDto;
 
@@ -12,4 +13,8 @@ public interface MemberService {
     boolean signUp(MemberSignUpRequestDto request);
 
     Optional<MemberInfoDto> getUserInfo(String userId);
+
+    boolean isMemberOfProject(Long projectId, String id);
+
+    Optional<Member> getMember(String id);
 }

--- a/src/main/java/com/example/issuetracker_server/service/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/member/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.issuetracker_server.service.member;
 
 import com.example.issuetracker_server.domain.member.Member;
 import com.example.issuetracker_server.domain.member.MemberRepository;
+import com.example.issuetracker_server.domain.memberproject.MemberProjectRepository;
 import com.example.issuetracker_server.dto.member.MemberInfoDto;
 import com.example.issuetracker_server.dto.member.MemberSignUpRequestDto;
 import jakarta.transaction.Transactional;
@@ -15,6 +16,7 @@ import java.util.Optional;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final MemberProjectRepository memberProjectRepository;
 
     @Override
     public boolean login(String id, String pw) {
@@ -60,5 +62,19 @@ public class MemberServiceImpl implements MemberService {
         } else {
             return Optional.empty();
         }
+    }
+
+    @Override
+    @Transactional
+    public boolean isMemberOfProject(Long projectId, String id) {
+        if(memberProjectRepository.findByMemberIdAndProjectId(id, projectId).isPresent())
+            return true;
+        return false;
+    }
+
+    @Override
+    @Transactional
+    public Optional<Member> getMember(String id) {
+        return memberRepository.findById(id);
     }
 }

--- a/src/main/java/com/example/issuetracker_server/service/memberproject/MemberProjectServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/memberproject/MemberProjectServiceImpl.java
@@ -58,7 +58,7 @@ public class MemberProjectServiceImpl implements MemberProjectService {
     public List<Project> getProjectIdByMemberId(String member_id){
         List<MemberProject> memberProjects = memberProjectRepository.findByMemberId(member_id);
         List<Long> projectIds = memberProjects.stream().map(memberProject -> memberProject.getProject().getId()).collect(Collectors.toList());
-        return projectRepository.findByUserId(projectIds);
+        return projectRepository.findByIds(projectIds);
     }
 
     public List<MemberProject> getMemberProjectByProjectId(Long project_id) {

--- a/src/test/java/com/example/issuetracker_server/controller/CommentControllerTest.java
+++ b/src/test/java/com/example/issuetracker_server/controller/CommentControllerTest.java
@@ -5,6 +5,7 @@ import com.example.issuetracker_server.domain.comment.CommentRepository;
 import com.example.issuetracker_server.domain.issue.Issue;
 import com.example.issuetracker_server.domain.member.Member;
 import com.example.issuetracker_server.dto.comment.CommentRequestDto;
+import com.example.issuetracker_server.dto.comment.CommentResponseDto;
 import com.example.issuetracker_server.service.comment.CommentServiceImpl;
 import com.example.issuetracker_server.service.issue.IssueServiceImpl;
 import com.example.issuetracker_server.service.member.MemberServiceImpl;
@@ -27,6 +28,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
@@ -123,21 +125,23 @@ public class CommentControllerTest {
 
     @Test
     public void getComments_Success() throws Exception {
-        Comment comment1 = new Comment();
-        comment1.setId(1L);
+        CommentResponseDto comment1 = new CommentResponseDto();
+        comment1.setComment_id(1L);
         comment1.setContent("Test Comment 1");
-        comment1.setAuthor(new Member("user1", "password", "User One", "ROLE_USER"));
-        comment1.setCreatedDate(LocalDateTime.now());
+        comment1.setAuthor_id("user1");
+        comment1.setCreated_date(String.valueOf(LocalDateTime.now()));
+        comment1.setAuthor_name("username");
 
-        Comment comment2 = new Comment();
-        comment2.setId(2L);
+        CommentResponseDto comment2 = new CommentResponseDto();
+        comment2.setComment_id(2L);
         comment2.setContent("Test Comment 2");
-        comment2.setAuthor(new Member("user2", "password", "User Two", "ROLE_USER"));
-        comment2.setCreatedDate(LocalDateTime.now());
+        comment2.setAuthor_id("user2");
+        comment2.setCreated_date(String.valueOf(LocalDateTime.now()));
+        comment2.setAuthor_name("user2name");
 
         when(memberService.login(anyString(), anyString())).thenReturn(true);
         when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
-        when(commentService.findByIssueId(anyLong())).thenReturn(Arrays.asList(comment1, comment2));
+        when(commentService.findByIssueId(anyLong())).thenReturn((List<CommentResponseDto>) Arrays.asList(comment1, comment2));
 
         mvc.perform(get(url + "1/issue/1/comment/")
                         .param("id", "user1")

--- a/src/test/java/com/example/issuetracker_server/controller/CommentControllerTest.java
+++ b/src/test/java/com/example/issuetracker_server/controller/CommentControllerTest.java
@@ -1,0 +1,277 @@
+package com.example.issuetracker_server.controller;
+
+import com.example.issuetracker_server.domain.comment.Comment;
+import com.example.issuetracker_server.domain.comment.CommentRepository;
+import com.example.issuetracker_server.domain.issue.Issue;
+import com.example.issuetracker_server.domain.member.Member;
+import com.example.issuetracker_server.dto.comment.CommentRequestDto;
+import com.example.issuetracker_server.service.comment.CommentServiceImpl;
+import com.example.issuetracker_server.service.issue.IssueServiceImpl;
+import com.example.issuetracker_server.service.member.MemberServiceImpl;
+import com.example.issuetracker_server.service.project.ProjectServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class CommentControllerTest {
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private CommentServiceImpl commentService;
+
+    @MockBean
+    private MemberServiceImpl memberService;
+
+    @MockBean
+    private ProjectServiceImpl projectService;
+
+    @MockBean
+    private IssueServiceImpl issueService;
+
+    @InjectMocks
+    private CommentController commentController;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    String url = "http://localhost:" + port + "/project/";
+    @Test
+    public void createComment_Success() throws Exception {
+        CommentRequestDto requestDto = new CommentRequestDto();
+        requestDto.setContent("Test Comment");
+
+        Member member = new Member();
+        member.setId("user1");
+
+        Issue issue = new Issue();
+        issue.setId(1L);
+
+        when(memberService.login(anyString(),anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(),anyString())).thenReturn(true);
+        when(memberService.getMember(anyString())).thenReturn(Optional.of(member));
+        when(issueService.getIssue(anyLong())).thenReturn(Optional.of(issue));
+
+        mvc.perform(post(url + "1/issue/1/comment/")
+
+                .param("id", "user1")
+                .param("pw","password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"content\":  \"Test Comment\"}"))
+                .andExpect(status().isOk());
+        verify(commentService, times(1)).save(any(Comment.class));
+    }
+
+    @Test
+    public void createComment_Unauthorized() throws Exception {
+        when(memberService.login(anyString(), anyString())).thenReturn(false);
+
+        mvc.perform(post(url + "1/issue/1/comment/")
+                        .param("id", "user1")
+                        .param("pw", "password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"Test Comment\"}"))
+                .andExpect(status().isUnauthorized());
+
+        verify(commentService, times(0)).save(any(Comment.class));
+    }
+
+    @Test
+    public void createComment_Forbidden() throws Exception {
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(false);
+
+        mvc.perform(post(url + "1/issue/1/comment/")
+                        .param("id", "user1")
+                        .param("pw", "password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"Test Comment\"}"))
+                .andExpect(status().isForbidden());
+
+        verify(commentService, times(0)).save(any(Comment.class));
+
+    }
+
+    @Test
+    public void getComments_Success() throws Exception {
+        Comment comment1 = new Comment();
+        comment1.setId(1L);
+        comment1.setContent("Test Comment 1");
+        comment1.setAuthor(new Member("user1", "password", "User One", "ROLE_USER"));
+        comment1.setCreatedDate(LocalDateTime.now());
+
+        Comment comment2 = new Comment();
+        comment2.setId(2L);
+        comment2.setContent("Test Comment 2");
+        comment2.setAuthor(new Member("user2", "password", "User Two", "ROLE_USER"));
+        comment2.setCreatedDate(LocalDateTime.now());
+
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
+        when(commentService.findByIssueId(anyLong())).thenReturn(Arrays.asList(comment1, comment2));
+
+        mvc.perform(get(url + "1/issue/1/comment/")
+                        .param("id", "user1")
+                        .param("pw", "password"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].content").value("Test Comment 1"))
+                .andExpect(jsonPath("$[1].content").value("Test Comment 2"));
+    }
+
+    @Test
+    public void updateComment_Success() throws Exception {
+        Comment comment = new Comment();
+        comment.setId(1L);
+        comment.setAuthor(new Member("user1", "password", "User One", "ROLE_USER"));
+        comment.setContent("Old Content");
+
+        CommentRequestDto requestDto = new CommentRequestDto();
+        requestDto.setContent("New Content");
+
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
+        when(commentService.findById(anyLong())).thenReturn(Optional.of(comment));
+
+        mvc.perform(put(url + "1/issue/1/comment/1")
+                        .param("id", "user1")
+                        .param("pw", "password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"New Content\"}"))
+                .andExpect(status().isOk());
+
+        verify(commentService, times(1)).save(any(Comment.class));
+    }
+
+    @Test
+    public void updateComment_Forbidden() throws Exception {
+        Comment comment = new Comment();
+        comment.setId(1L);
+        comment.setAuthor(new Member("user1", "password", "User One", "ROLE_USER"));
+        comment.setContent("Old Content");
+
+        CommentRequestDto requestDto = new CommentRequestDto();
+        requestDto.setContent("New Content");
+
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
+        when(commentService.findById(anyLong())).thenReturn(Optional.of(comment));
+
+        mvc.perform(put(url + "1/issue/1/comment/1")
+                        .param("id", "user2")
+                        .param("pw", "password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"New Content\"}"))
+                .andExpect(status().isForbidden());
+
+        verify(commentService, times(0)).save(any(Comment.class));
+    }
+
+    @Test
+    public void updateComment_BadRequest() throws Exception {
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
+        when(commentService.findById(anyLong())).thenReturn(Optional.empty());
+
+        mvc.perform(put(url + "1/issue/1/comment/1")
+                        .param("id", "user1")
+                        .param("pw", "password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\": \"New Content\"}"))
+                .andExpect(status().isBadRequest());
+
+        verify(commentService, times(0)).save(any(Comment.class));
+    }
+
+    @Test
+    public void deleteComment_Success() throws Exception {
+        Comment comment = new Comment();
+        comment.setId(1L);
+        comment.setAuthor(new Member("user1", "password", "User One", "ROLE_USER"));
+
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
+        when(commentService.findById(anyLong())).thenReturn(Optional.of(comment));
+
+        mvc.perform(delete(url + "1/issue/1/comment/1")
+                        .param("id", "user1")
+                        .param("pw", "password"))
+                .andExpect(status().isOk());
+
+        verify(commentService, times(1)).delete(anyLong());
+    }
+
+    @Test
+    public void deleteComment_Unauthorized() throws Exception {
+        when(memberService.login(anyString(), anyString())).thenReturn(false);
+
+        mvc.perform(delete(url + "1/issue/1/comment/1")
+                        .param("id", "user1")
+                        .param("pw", "password"))
+                .andExpect(status().isUnauthorized());
+
+        verify(commentService, times(0)).delete(anyLong());
+    }
+
+    @Test
+    public void deleteComment_Forbidden_NotCommentAuthor() throws Exception {
+        Comment comment = new Comment();
+        comment.setId(1L);
+        comment.setAuthor(new Member("user2", "password", "User Two", "ROLE_USER"));
+
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
+        when(commentService.findById(anyLong())).thenReturn(Optional.of(comment));
+
+        mvc.perform(delete(url + "1/issue/1/comment/1")
+                        .param("id", "user1")
+                        .param("pw", "password"))
+                .andExpect(status().isForbidden());
+
+        verify(commentService, times(0)).delete(anyLong());
+    }
+
+    @Test
+    public void deleteComment_NotFound() throws Exception {
+        when(memberService.login(anyString(), anyString())).thenReturn(true);
+        when(memberService.isMemberOfProject(anyLong(), anyString())).thenReturn(true);
+        when(commentService.findById(anyLong())).thenReturn(Optional.empty());
+
+        mvc.perform(delete(url + "1/issue/1/comment/1")
+                        .param("id", "user1")
+                        .param("pw", "password"))
+                .andExpect(status().isBadRequest());
+
+        verify(commentService, times(0)).delete(anyLong());
+    }
+}
+

--- a/src/test/java/com/example/issuetracker_server/controller/ProjectControllerTest.java
+++ b/src/test/java/com/example/issuetracker_server/controller/ProjectControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -84,6 +85,7 @@ public class ProjectControllerTest {
                 .build();
 
         MockitoAnnotations.openMocks(this);
+
     }
 
     @Test


### PR DESCRIPTION
### 요약
- Comment 의 CRUD와 관련된 API를 구현하였습니다
---
### 각 기능별 함수
1. POST /project/{projectId}/issue/{issueId}/comment
<img width="879" alt="image" src="https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/84865066/7d044703-a07b-4f1e-bfed-388b1be7138e">

2. GET /project/{projectId}/issue/{issueId}/comment
<img width="934" alt="image" src="https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/84865066/710c48be-fa5b-45dd-9f96-adf5dbd02e69">

3. PUT /project/{projectId}/issue/{issueId}/comment/{commentId}
<img width="915" alt="image" src="https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/84865066/ebd6ec04-3b03-428c-9a93-f367d7af3866">

4. DELETE /project/{projectId}/issue/{issueId}/comment/{commentId}
<img width="916" alt="image" src="https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/84865066/bbcfbb3f-e48e-4b71-bc0b-0c6fb39751c8">
--- 
### 테스트코드 

1. 코멘트 생성
- createComment_Success
- createComment_Unauthorized
- createComment_Forbidden

2. 코멘트 읽기
- getComments_Success

3. 코멘트 수정
- updateComment_Success
- updateComment_Forbidden
- updateComment_BadRequest

4. 코멘트 삭제
- deleteComment_Success
- deleteComment_Unauthorized
- deleteComment_Forbidden_notCommentAuthor
- deleteComment_NotFound

<img width="262" alt="image" src="https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/84865066/bbf84e34-fcb3-46ed-aa75-1355663cf87a">

