### PR TITLE
[DEV] issue statistic GET 요청 구현

### DIFF
--- a/src/main/java/com/example/issuetracker_server/controller/IssueController.java
+++ b/src/main/java/com/example/issuetracker_server/controller/IssueController.java
@@ -6,6 +6,7 @@ import com.example.issuetracker_server.dto.issue.IssueAssignRequestDto;
 import com.example.issuetracker_server.dto.issue.IssueCreateRequestDto;
 import com.example.issuetracker_server.dto.issue.IssueResponseDto;
 import com.example.issuetracker_server.dto.issue.IssueStateRequest;
+import com.example.issuetracker_server.dto.issue.IssueStatisticResponseDto;
 import com.example.issuetracker_server.service.issue.IssueService;
 import com.example.issuetracker_server.service.member.MemberService;
 import com.example.issuetracker_server.service.memberproject.MemberProjectService;
@@ -48,9 +49,8 @@ public class IssueController {
     }
 
 
-    @GetMapping("/{issueId}")
+    @GetMapping
     public ResponseEntity<List<IssueResponseDto>> getIssues(@PathVariable Long projectId,
-                                                            @PathVariable Long issueId,
                                                             @RequestParam String id,
                                                             @RequestParam String pw,
                                                             @RequestParam(required = false) String filterBy,
@@ -68,6 +68,34 @@ public class IssueController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
+    }
+
+    @GetMapping("/{issueId}")
+    public ResponseEntity<IssueResponseDto> getIssue(@PathVariable Long projectId, @PathVariable Long issueId,
+                                                     @RequestParam String id, @RequestParam String pw) {
+        if (!memberService.login(id, pw))
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+        Optional<Role> role = memberProjectService.getRole(id, projectId);
+        if (role.isEmpty())
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        Optional<IssueResponseDto> issue = issueService.getIssue(projectId, issueId);
+
+        if (issue.isPresent())
+            return ResponseEntity.ok(issue.get());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+    @GetMapping("/statistic")
+    public ResponseEntity<IssueStatisticResponseDto> getStatistic(@PathVariable Long projectId, @RequestParam String id, @RequestParam String pw) {
+        if (!memberService.login(id, pw))
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+        Optional<Role> role = memberProjectService.getRole(id, projectId);
+        if (role.isEmpty())
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+
+        return ResponseEntity.ok(issueService.getStatistic(projectId));
     }
 
 

--- a/src/main/java/com/example/issuetracker_server/dto/issue/IssueStatisticResponseDto.java
+++ b/src/main/java/com/example/issuetracker_server/dto/issue/IssueStatisticResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.issuetracker_server.dto.issue;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class IssueStatisticResponseDto {
+    private int day_issues;
+    private int month_issues;
+    private int total_issues;
+    private int closed_issues;
+}

--- a/src/main/java/com/example/issuetracker_server/service/issue/IssueService.java
+++ b/src/main/java/com/example/issuetracker_server/service/issue/IssueService.java
@@ -7,6 +7,7 @@ import com.example.issuetracker_server.domain.issue.State;
 import com.example.issuetracker_server.domain.memberproject.Role;
 import com.example.issuetracker_server.dto.issue.IssueCreateRequestDto;
 import com.example.issuetracker_server.dto.issue.IssueResponseDto;
+import com.example.issuetracker_server.dto.issue.IssueStatisticResponseDto;
 
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,8 @@ public interface IssueService {
     List<IssueResponseDto> getIssues(Long projectId, String filterBy, String filterValue);
 
     Optional<IssueResponseDto> getIssue(Long projectId, Long issueId);
+
+    IssueStatisticResponseDto getStatistic(Long ProjectId);
 
     Map<String, List<String>> getRecommendAssignee(Long projectId, Long issueId);
 

--- a/src/main/java/com/example/issuetracker_server/service/issue/IssueServiceImpl.java
+++ b/src/main/java/com/example/issuetracker_server/service/issue/IssueServiceImpl.java
@@ -13,9 +13,11 @@ import com.example.issuetracker_server.domain.project.Project;
 import com.example.issuetracker_server.domain.project.ProjectRepository;
 import com.example.issuetracker_server.dto.issue.IssueCreateRequestDto;
 import com.example.issuetracker_server.dto.issue.IssueResponseDto;
+import com.example.issuetracker_server.dto.issue.IssueStatisticResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -106,6 +108,29 @@ public class IssueServiceImpl implements IssueService {
     public Optional<IssueResponseDto> getIssue(Long projectId, Long issueId) {
         Optional<Issue> issue = issueRepository.findById(issueId);
         return issue.map(this::toDto);
+    }
+
+    @Override
+    public IssueStatisticResponseDto getStatistic(Long ProjectId)
+    {
+        List<Issue> issues = issueRepository.findByProjectId(ProjectId);
+
+        int dayIssues = (int) issues.stream()
+                .filter(issue -> issue.getCreatedDate().toLocalDate().equals(LocalDate.now()))
+                .count();
+
+        int monthIssues = (int) issues.stream()
+                .filter(issue -> issue.getCreatedDate().toLocalDate().getMonth() == LocalDate.now().getMonth() &&
+                        issue.getCreatedDate().toLocalDate().getYear() == LocalDate.now().getYear())
+                .count();
+
+        int totalIssues = issues.size();
+
+        int closedIssues = (int) issues.stream()
+                .filter(issue -> issue.getState() == State.CLOSED)
+                .count();
+
+        return new IssueStatisticResponseDto(dayIssues, monthIssues, totalIssues, closedIssues);
     }
 
     @Override

--- a/src/test/java/com/example/issuetracker_server/controller/IssueControllerTest.java
+++ b/src/test/java/com/example/issuetracker_server/controller/IssueControllerTest.java
@@ -251,6 +251,103 @@ public class IssueControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    public void testGetIssueSuccess() throws Exception {
+        // Given
+        String id = "testuser";
+        String pw = "password";
+        Long projectId = 1L;
+        Long issueId = 2L;
+
+        IssueResponseDto issue = IssueResponseDto.builder()
+                .id(issueId)
+                .title("issue title")
+                .description("issue description")
+                .state(State.NEW)
+                .build();
+
+        when(memberService.login(id, pw)).thenReturn(true);
+        when(memberProjectService.getRole(id, projectId)).thenReturn(Optional.of(Role.TESTER));
+        when(issueService.getIssue(projectId, issueId)).thenReturn(Optional.of(issue));
+
+        // When
+        mockMvc.perform(get("/project/" + projectId + "/issue/" + issueId)
+                        .param("id", id)
+                        .param("pw", pw)
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                // Then
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(issueId))
+                .andExpect(jsonPath("$.title").value("issue title"))
+                .andExpect(jsonPath("$.description").value("issue description"))
+                .andExpect(jsonPath("$.state").value(State.NEW.toString()));
+    }
+
+    @Test
+    public void testGetIssueUnauthorized() throws Exception {
+        // Given
+        String id = "testuser";
+        String pw = "wrongpassword";
+        Long projectId = 1L;
+        Long issueId = 2L;
+
+        when(memberService.login(id, pw)).thenReturn(false);
+
+        // When
+        mockMvc.perform(get("/project/" + projectId + "/issue/" + issueId)
+                        .param("id", id)
+                        .param("pw", pw)
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                // Then
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testGetIssueForbidden() throws Exception {
+        // Given
+        String id = "testuser";
+        String pw = "password";
+        Long projectId = 1L;
+        Long issueId = 2L;
+
+        when(memberService.login(id, pw)).thenReturn(true);
+        when(memberProjectService.getRole(id, projectId)).thenReturn(Optional.empty());
+
+        // When
+        mockMvc.perform(get("/project/" + projectId + "/issue/" + issueId)
+                        .param("id", id)
+                        .param("pw", pw)
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                // Then
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void testGetIssueNotFound() throws Exception {
+        // Given
+        String id = "testuser";
+        String pw = "password";
+        Long projectId = 1L;
+        Long issueId = 2L;
+
+        when(memberService.login(id, pw)).thenReturn(true);
+        when(memberProjectService.getRole(id, projectId)).thenReturn(Optional.of(Role.TESTER));
+        when(issueService.getIssue(projectId, issueId)).thenReturn(Optional.empty());
+
+        // When
+        mockMvc.perform(get("/project/" + projectId + "/issue/" + issueId)
+                        .param("id", id)
+                        .param("pw", pw)
+                        .contentType(MediaType.APPLICATION_JSON))
+
+                // Then
+                .andExpect(status().isNotFound());
+    }
+
 
     @Test
     public void testGetRecommendAssigneeUnauthorized() throws Exception {


### PR DESCRIPTION
- 프로젝트의 이슈 통계를 보여주는 GET요청에 해당하는 API 구현
- 요청은 다음과 같은 응답을 보냅니다.
> ```json
> {
>     "day_issues": 0,
>     "month_issues": 0,
>     "total_issues": 0,
>     "closed_issues": 0
> }
> ```
- 총 103개의 Junit test 수행 결과를 확인했습니다.
> <img width="648" alt="image" src="https://github.com/CAU-SWE-Team4/IssueTracker_Server/assets/27052038/615df4c2-8923-474a-b9a7-d3e8d0ebdb95">
